### PR TITLE
FA- 22-아티스트-프로필-상세-조회-페이지-artist-profile-detail-view-page

### DIFF
--- a/artist_profile/artist_profile_detail.css
+++ b/artist_profile/artist_profile_detail.css
@@ -27,7 +27,7 @@ body {
 
 .divider {
     width: 100%;
-    height: 0.5px;
+    height: 1px;
     background-color: #C3C3C3;
     margin-bottom: 20px;
 }

--- a/artist_profile/artist_profile_detail.html
+++ b/artist_profile/artist_profile_detail.html
@@ -10,9 +10,9 @@
 <body>
 <div class="container">
     <h1 class="title">아티스트</h1>
-    <hr class="divider">  <!-- 회색 얇은 선 추가 -->
+    <hr class="divider">
     <div class="artist-info">
-        <img class="artist-image" src="image" alt="Artist Image">
+        <img class="artist-image" src="https://namu.wiki/w/%ED%8C%8C%EC%9D%BC:VanGogh_1887.jpg" alt="Artist Image">
         <div class="artist-description">
             <h2 class="artist-name">고흐</h2>
             <div class="artist-details">


### PR DESCRIPTION
나무위키 사진이 이미지 url 연동이 안 된다고 해서 일단은 비워놨습니다.
선 색상이 figma와 일치하게끔 만들었지만 색이 좀 더 진하게 나오네요 ..

![image](https://github.com/ArtBridge-s/FE-ArtBridge/assets/116442499/8191dedf-9078-4bd2-952a-d9bd1c5f03dd)
