### PR TITLE
FA-51-아티스트 프로필 상세 페이지 수정

### DIFF
--- a/domain/artist/detail.html
+++ b/domain/artist/detail.html
@@ -58,6 +58,10 @@
       const career = document.getElementById('artist-career');
       const img = document.getElementsByClassName('artist-image');
       console.log(data.name);
+      img.src =
+        data?.imgUrl === undefined
+          ? 'https://namu.wiki/w/%ED%8C%8C%EC%9D%BC:VanGogh_1887.jpg'
+          : data.imgUrl;
       name.textContent = data?.name === undefined ? '알 수 없음' : data.name;
       fullName.textContent =
         data?.realName === undefined ? '알 수 없음' : data.realName;


### PR DESCRIPTION
상세 페이지에 이미지 데이터를 넣는 부분이 없어 추가해줬습니다 현재 백엔드로부터 데이터를 가져올 때 이미지 url이 경로가 제대로 되어있지 않은 부분이 많아 현재 이미지 보여지기는 힘들 것 같습니다 또한 값이 undefined인 경우 원래 나무위키값으로 저장해두었습니다